### PR TITLE
Fixing article variable in News admin_add.

### DIFF
--- a/app/plugins/news/views/admin/add.php
+++ b/app/plugins/news/views/admin/add.php
@@ -13,7 +13,7 @@
 					<div id="pagecontent" class="accordion-body">
 						<div class="accordion-inner">
 							<div class="controls">
-								<input type="text" name="title" id="form-title" value="<?= $aPost['title'] ?>" class="span12 validate[required]">
+								<input type="text" name="title" id="form-title" value="<?= $aArticle['title'] ?>" class="span12 validate[required]">
 							</div>
 						</div>
 					</div>
@@ -26,7 +26,7 @@
 					<div class="accordion-body">
 						<div class="accordion-inner">
 							<div class="controls">
-								<?= html_editor($aPost['content'], "content") ?>
+								<?= html_editor($aArticle['content'], "content") ?>
 							</div>
 						</div>
 					</div>
@@ -39,7 +39,7 @@
 					<div class="accordion-body">
 						<div class="accordion-inner">
 							<div class="controls">
-								<textarea name="excerpt" class="span12" style="height:115px;"><?= $aPost['excerpt'] ?></textarea>
+								<textarea name="excerpt" class="span12" style="height:115px;"><?= $aArticle['excerpt'] ?></textarea>
 								<p class="help-block"><span id="currentCharacters"></span> of <?= $sExcerptCharacters ?> characters</p>
 							</div>
 						</div>
@@ -57,7 +57,7 @@
 								<?php if(!empty($aCategories)): ?>
 									<select name="categories[]" data-placeholder="Select Categories" class="chzn-select span12" multiple="">
 										<?php foreach($aCategories as $aCategory): ?>
-											<option value="<?= $aCategory['id'] ?>"<?php if(in_array($aCategory['id'], $aPost['categories'])){ echo ' selected="selected"'; } ?>><?= $aCategory['name'] ?></option>
+											<option value="<?= $aCategory['id'] ?>"<?php if(in_array($aCategory['id'], $aArticle['categories'])){ echo ' selected="selected"'; } ?>><?= $aCategory['name'] ?></option>
 										<?php endforeach; ?>
 	             		</select>
 
@@ -97,8 +97,8 @@
 						<div class="accordion-inner">
 							<div class="control-group">
 								<div class="controls timepicker">
-									<input type="input" name="publish_on_date" value="<?= $aPost['publish_on_date'] ?>" id="datepicker" class="span12">
-									@ <?= html_select_time($aPost['publish_on'], "publish_on_", 15, false, false); ?>
+									<input type="input" name="publish_on_date" value="<?= $aArticle['publish_on_date'] ?>" id="datepicker" class="span12">
+									@ <?= html_select_time($aArticle['publish_on'], "publish_on_", 15, false, false); ?>
 
 									<p class="help-block">If the date is in the future, it will not show on the site till then.</p>
 								</div>
@@ -115,11 +115,11 @@
 						<div class="accordion-inner">
 							<div class="control-group">
 								<div class="controls">
-									<label class="checkbox"><input type="checkbox" name="post_twitter" value="1"<?php if($aPost['post_twitter'] == 1){ echo ' checked="checked"'; } ?>> <img src="/images/admin/social/twitter.png" width="15px"> Share this post to Twitter.</label>
+									<label class="checkbox"><input type="checkbox" name="post_twitter" value="1"<?php if($aArticle['post_twitter'] == 1){ echo ' checked="checked"'; } ?>> <img src="/images/admin/social/twitter.png" width="15px"> Share this post to Twitter.</label>
 								</div>
 
 								<div class="controls">
-									<label class="checkbox"><input type="checkbox" name="post_facebook" value="1"<?php if($aPost['post_facebook'] == 1){ echo ' checked="checked"'; } ?>> <img src="/images/admin/social/facebook_32.png" width="15px"> Share this post to Facebook.</label>
+									<label class="checkbox"><input type="checkbox" name="post_facebook" value="1"<?php if($aArticle['post_facebook'] == 1){ echo ' checked="checked"'; } ?>> <img src="/images/admin/social/facebook_32.png" width="15px"> Share this post to Facebook.</label>
 								</div>
 							</div>
 						</div>
@@ -135,21 +135,21 @@
 							<div class="control-group">
 								<label class="control-label" for="form-tag">Title</label>
 								<div class="controls">
-									<input type="text" name="seo_title" id="form-tags" value="<?= $aPost['seo_title'] ?>" class="span12">
+									<input type="text" name="seo_title" id="form-tags" value="<?= $aArticle['seo_title'] ?>" class="span12">
 								</div>
 							</div>
 
 							<div class="control-group">
 								<label class="control-label" for="form-tag">Description</label>
 								<div class="controls">
-									<textarea name="seo_description" id="form-tags" style="height:95px;" class="span12"><?= $aPost['seo_description'] ?></textarea>
+									<textarea name="seo_description" id="form-tags" style="height:95px;" class="span12"><?= $aArticle['seo_description'] ?></textarea>
 								</div>
 							</div>
 
 							<div class="control-group">
 								<label class="control-label" for="form-tag">Keywords</label>
 								<div class="controls">
-									<textarea name="seo_keywords" id="form-tags" style="height:95px;" class="span12"><?= $aPost['seo_keywords'] ?></textarea>
+									<textarea name="seo_keywords" id="form-tags" style="height:95px;" class="span12"><?= $aArticle['seo_keywords'] ?></textarea>
 								</div>
 							</div>
 						</div>
@@ -163,7 +163,7 @@
 					<div class="accordion-body in collapse">
 						<div class="accordion-inner">
 							<div class="controls">
-								<textarea name="tags" id="form-tags" style="height:115px;" class="span12"><?= $aPost['tags'] ?></textarea>
+								<textarea name="tags" id="form-tags" style="height:115px;" class="span12"><?= $aArticle['tags'] ?></textarea>
 								<p class="help-block">Comma separated list of keywords.</p>
 							</div>
 						</div>


### PR DESCRIPTION
News admin_add was using `$aPost` which was left over from duplicating Posts. Should have been using `$aArticle` as the variable. :monkey: 

Reference help desk ticket #12406.

:shipit: 